### PR TITLE
Update to support RN 0.47

### DIFF
--- a/android/src/main/java/in/sriraman/sharedpreferences/RNSharedPreferencesReactPackage.java
+++ b/android/src/main/java/in/sriraman/sharedpreferences/RNSharedPreferencesReactPackage.java
@@ -31,15 +31,6 @@ public class RNSharedPreferencesReactPackage implements ReactPackage {
   }
 
 
-
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-  }
-
-
-
-
   @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       List<ViewManager> result = new ArrayList<ViewManager>();


### PR DESCRIPTION
RN 0.47 removed the need for createJSModules, see https://github.com/facebook/react-native/releases/tag/v0.47.2