### PR TITLE
make shared name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ public class MainActivity extends ReactActivity {
 var SharedPreferences = require('react-native-shared-preferences');
 ```
 
+#### Configure name of preferences file. (Optional. Must be called before other functions.)
+
+```javascript
+SharedPreferences.setName("name");
+```
+
 #### Set Item
 
 ```javascript

--- a/android/src/main/java/in/sriraman/sharedpreferences/RNSharedPreferencesModule.java
+++ b/android/src/main/java/in/sriraman/sharedpreferences/RNSharedPreferencesModule.java
@@ -57,6 +57,7 @@ public class RNSharedPreferencesModule extends ReactContextBaseJavaModule {
 	private ArrayList<BluetoothDevice> bt_device_list = null;
 	private boolean bt_scanning = false;
 	private boolean is_watch = false;
+	private String shared_name = "wit_player_shared_preferences";
 
 	private BroadcastReceiver bt_info_receiver = null;
 
@@ -69,22 +70,29 @@ public class RNSharedPreferencesModule extends ReactContextBaseJavaModule {
 	}
 
 
-
+	private void initSharedHandler() {
+		SharedHandler.init(getReactApplicationContext(), shared_name);		
+	}
 
 	public RNSharedPreferencesModule(ReactApplicationContext reactContext) {
 		super(reactContext);
 	}
 
 	@Override
-		public String getName() {
-			return "SharedPreferences";
-		}
+	public String getName() {
+		return "SharedPreferences";
+	}
+
+	@ReactMethod
+	public void setName(String name) {
+		shared_name = name;
+	}
 
 
 	@ReactMethod
 		public void setItem(String key, String value) {
 
-			SharedHandler.init(getReactApplicationContext());
+			initSharedHandler();
 			SharedDataProvider.putSharedValue(key,value);
 
 		}
@@ -92,7 +100,7 @@ public class RNSharedPreferencesModule extends ReactContextBaseJavaModule {
 	@ReactMethod
 		public void getItem(String key, Callback successCallback){
 
-			SharedHandler.init(getReactApplicationContext());
+			initSharedHandler();
 			String value = SharedDataProvider.getSharedValue(key);
 			successCallback.invoke(value);
 
@@ -104,7 +112,7 @@ public class RNSharedPreferencesModule extends ReactContextBaseJavaModule {
 	 * */
 	@ReactMethod
 		    public void getItems(ReadableArray keys, Callback successCallback){
-			    SharedHandler.init(getReactApplicationContext());
+			    initSharedHandler();
 			    String[] keysArray= new String[keys.size()];
 			    for (int i=0;i<keys.size();i++){
 				    keysArray[i]=keys.getString(i);
@@ -119,7 +127,7 @@ public class RNSharedPreferencesModule extends ReactContextBaseJavaModule {
 
 	@ReactMethod
 		public void getAll(Callback successCallback){
-			SharedHandler.init(getReactApplicationContext());
+			initSharedHandler();
 			String[][] values = SharedDataProvider.getAllSharedValues();
 			WritableNativeArray data = new WritableNativeArray();
 			for(int i=0; i<values.length; i++){
@@ -145,7 +153,7 @@ public class RNSharedPreferencesModule extends ReactContextBaseJavaModule {
 
 	@ReactMethod
 		public void getAllKeys(Callback successCallback){
-			SharedHandler.init(getReactApplicationContext());
+			initSharedHandler();
 			String[] keys = SharedDataProvider.getAllKeys();
 			WritableNativeArray data = new WritableNativeArray();
 			for(int i=0; i<keys.length; i++){
@@ -158,14 +166,14 @@ public class RNSharedPreferencesModule extends ReactContextBaseJavaModule {
 
 	@ReactMethod
 		public void clear(){
-			SharedHandler.init(getReactApplicationContext());
+			initSharedHandler();
 			SharedDataProvider.clear();
 		}
 
 
 	@ReactMethod
 		public void removeItem(String key) {
-			SharedHandler.init(getReactApplicationContext());
+			initSharedHandler();
 			SharedDataProvider.deleteSharedValue(key);
 		}
 

--- a/android/src/main/java/in/sriraman/sharedpreferences/SharedHandler.java
+++ b/android/src/main/java/in/sriraman/sharedpreferences/SharedHandler.java
@@ -7,24 +7,22 @@ import java.util.Map;
 
 public class SharedHandler {
 
-    private static final String SHARED_NAME = "wit_player_shared_preferences";
-
     private SharedPreferences mSharedPreferences;
 
     private static SharedHandler sSharedHandler;
 
-    public SharedHandler(Context context) {
-        mSharedPreferences = context.getSharedPreferences(SHARED_NAME, Context.MODE_PRIVATE);
+    public SharedHandler(Context context, String name) {
+        mSharedPreferences = context.getSharedPreferences(name, Context.MODE_PRIVATE);
     }
 
     public static SharedHandler getInstance() {
         return sSharedHandler;
     }
 
-    public static void init(Context context) {
-	if (sSharedHandler==null) {
-            sSharedHandler = new SharedHandler(context);
-	}
+    public static void init(Context context, String name) {
+        if (sSharedHandler == null) {
+            sSharedHandler = new SharedHandler(context, name);
+        }
     }
 
     public void putExtra(String key, Object value) {


### PR DESCRIPTION
I am using this library to keep using the shared preferences that I was using before I switched to React Native. This pull request allows you to configure the name of the preferences file. I have kept the name to "wit_player_shared_preferences" when not set for backwards compatibility reasons.