### PR TITLE
Make versions in build.gradle configurable

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,17 @@
 apply plugin: 'com.android.library'
 
+def DEFAULT_COMPILE_SDK_VERSION             = 23
+def DEFAULT_BUILD_TOOLS_VERSION             = "23.0.1"
+def DEFAULT_TARGET_SDK_VERSION              = 23
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
buildToolsVersion, compileSdkVersion, targetSdkVersion.

This is necessary to use with newer SDK versions.