### PR TITLE
Renamed getMultipleItems to getItems in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,8 +5,8 @@ declare module "react-native-shared-preferences" {
     const setName: (name: string) => void;
     const setItem: (key: string , value: string) => void;
     const getItem: (key: string, callback: GetItemCallback) => void;
-    const getMultipleItems: (keys: string[] , calback: GetMultipleItemsCallback) => void;
-    const getAll: (calback: GetMultipleItemsCallback) => void;
+    const getItems: (keys: string[], callback: GetMultipleItemsCallback) => void;
+    const getAll: (callback: GetMultipleItemsCallback) => void;
     const clear: () => void;
     const getAllKeys: (callback: GetMultipleItemsCallback) => void;
     const removeItem: (key: string) => void;


### PR DESCRIPTION
There is no method called `getMultipleItems` in [RNSharedPreferencesModule.java](../blob/master/android/src/main/java/in/sriraman/sharedpreferences/RNSharedPreferencesModule.java). Changed to `getItems`, which is not in the type def.

Also fixed callback typo in `getAll`